### PR TITLE
Fix 修饰键重复修复功能，微软补丁后导致无法连跳

### DIFF
--- a/ezorsia/FixIme.h
+++ b/ezorsia/FixIme.h
@@ -165,15 +165,6 @@ public:
 		// �̳����� ����/����/���ݡ����������ս���IME / �������ݾ��ɵ������뷨
 		// �ϻ����� ��������򡪡���������������
 	}
-private:
-	static bool IsModifierHoldFixEnabled() {
-		INIReader reader("config.ini");
-		if (reader.ParseError() == 0) {
-			return reader.GetBoolean("general", "FixModifierHold", true);
-		}
-		return true;
-	}
-
 	static void GeneralHook() {
 		Memory::FillBytes(0x008D54A6, 0x90, 9); // Key (unconditional - char filter breaks IME)
 		Memory::FillBytes(0x00937225, 0x90, 9); // Chat

--- a/ezorsia/FixIme.h
+++ b/ezorsia/FixIme.h
@@ -1,15 +1,14 @@
 #pragma once
 #include <imm.h>
-#include "INIReader.h"
 #pragma comment(lib, "imm32.lib")
 
-void EnableIme() { // Ä¿Ç°Ã»ï¿½ï¿½ï¿½Ãµï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Î´ï¿½ï¿½ï¿½ï¿½Ð§ï¿½ï¿½
-	HWND hwnd = GetForegroundWindow(); // ï¿½ï¿½È¡ï¿½ï¿½Ç°Ç°Ì¨ï¿½ï¿½ï¿½ÚµÄ¾ï¿½ï¿½
+void EnableIme() { // Ä¿Ç°Ã»ÓÐÓÃµ½Õâ¸ö·½·¨£¬Î´²âÊÔÐ§¹û
+	HWND hwnd = GetForegroundWindow(); // »ñÈ¡µ±Ç°Ç°Ì¨´°¿ÚµÄ¾ä±ú
 	if (hwnd) {
-		// ï¿½ï¿½È¡ï¿½ï¿½ï¿½ë·¨ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+		// »ñÈ¡ÊäÈë·¨ÉÏÏÂÎÄ
 		HIMC hImc = ImmGetContext(hwnd);
 		if (hImc) {
-			// ï¿½ï¿½ï¿½ï¿½ï¿½ë·¨ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Â¹ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+			// ½«ÊäÈë·¨ÉÏÏÂÎÄÖØÐÂ¹ØÁªµ½´°¿Ú
 			ImmAssociateContext(hwnd, hImc);
 			ImmReleaseContext(hwnd, hImc);
 		}
@@ -17,12 +16,12 @@ void EnableIme() { // Ä¿Ç°Ã»ï¿½ï¿½ï¿½Ãµï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Î´ï¿½ï¿½ï¿½
 }
 
 void DisableIme() {
-	HWND hwnd = GetForegroundWindow(); // ï¿½ï¿½È¡ï¿½ï¿½Ç°Ç°Ì¨ï¿½ï¿½ï¿½ÚµÄ¾ï¿½ï¿½
+	HWND hwnd = GetForegroundWindow(); // »ñÈ¡µ±Ç°Ç°Ì¨´°¿ÚµÄ¾ä±ú
 	if (hwnd) {
-		// ï¿½ï¿½È¡ï¿½ï¿½ï¿½ë·¨ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+		// »ñÈ¡ÊäÈë·¨ÉÏÏÂÎÄ
 		HIMC hImc = ImmGetContext(hwnd);
 		if (hImc) {
-			// ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ë·¨ï¿½ï¿½ï¿½ï¿½ï¿½ÄµÄ¹ï¿½ï¿½ï¿½
+			// ½â³ýÊäÈë·¨ÉÏÏÂÎÄµÄ¹ØÁª
 			ImmAssociateContext(hwnd, NULL);
 			ImmReleaseContext(hwnd, hImc);
 		}
@@ -36,7 +35,7 @@ DWORD funcEnableImeAddr = 0x009E85F3;
 DWORD setOnFocusFirstJudgementRtnAddr = 0x004CA061;
 DWORD switchImeAddr = 0x004CA078;
 __declspec(naked) void setOnFocusFirstJudgement() {
-	// ï¿½ï¿½ï¿½ï¿½Ô­ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ö±ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ð»ï¿½IMEï¿½ÄµØ·ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Òªï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ð»ï¿½IMEï¿½ÄµØ·ï¿½
+	// ÕâÀïÔ­º¯Êý»áÖ±½ÓÌø¹ýÇÐ»»IMEµÄµØ·½£¬ÎÒÃÇÒªÈÃËûÌøµ½ÇÐ»»IMEµÄµØ·½
 	__asm {
 		cmp[esp + 0Ch], edi
 		jz label_jmp_switch_ime
@@ -89,7 +88,7 @@ __declspec(naked) void switchMLIme() {
 DWORD newSwitchImeRtnAddr = 0x004CA08F;
 __declspec(naked) void newSwitchIme() {
 	__asm {
-		cmp[esi + 0x80], 1 // ï¿½Ð¶ï¿½ï¿½Ç·ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+		cmp[esi + 0x80], 1 // ÅÐ¶ÏÊÇ·ñÃÜÂë¿ò
 		jz label_disable
 		push 1
 		call funcEnableImeAddr
@@ -134,45 +133,45 @@ __declspec(naked) void newSwitchMLIme() {
 class FixIme {
 public:
 	static void HookOld() {
-		// ï¿½ÊºÏ½Ï¾Éµï¿½win10ÏµÍ³
-		// ï¿½ï¿½Öªï¿½ï¿½ï¿½â£ºï¿½Ì³Çµï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Í£ï¿½ï¿½ï¿½Ð´ï¿½ï¿½ï¿½ÝµÄµØ·ï¿½ï¿½ï¿½ï¿½Þ·ï¿½ï¿½ï¿½ï¿½ï¿½IME
+		// ÊÊºÏ½Ï¾ÉµÄwin10ÏµÍ³
+		// ÒÑÖªÎÊÌâ£ºÉÌ³ÇµÄÀñÎïÔùËÍ£¬ÌîÐ´ÄÚÈÝµÄµØ·½»áÎÞ·¨µ÷³öIME
 
 		GeneralHook();
-		// ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½OnSetFocus@CCtrlEdit
+		// µ¥ÐÐÊäÈë¿òOnSetFocus@CCtrlEdit
 		Memory::CodeCave(setOnFocusFirstJudgement, 0x004CA05B, 6);
 		Memory::CodeCave(switchIme, 0x004CA089, 6);
-		// ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½OnSetFocus@CCtrlMLEdit
+		// ¶àÐÐÊäÈë¿òOnSetFocus@CCtrlMLEdit
 		Memory::FillBytes(0x004D32C6, 0x90, 2);
 		Memory::CodeCave(switchMLIme, 0x004D32D9, 7);
-		Memory::CodeCave(destroyWindow, 0x004DFEA4, 9); // ï¿½ï¿½ï¿½Ù´ï¿½ï¿½ï¿½Ê±ï¿½Ì¶ï¿½ï¿½ï¿½ï¿½ï¿½IME
+		Memory::CodeCave(destroyWindow, 0x004DFEA4, 9); // Ïú»Ù´°¿ÚÊ±¹Ì¶¨½ûÓÃIME
 		std::cout << "Old Ime Hook" << std::endl;
 	}
 
 	static void HookNew() {
-		// ï¿½ÊºÏ½ï¿½ï¿½Âµï¿½win10ÏµÍ³ï¿½ï¿½win11ÏµÍ³
-		// ï¿½ï¿½ï¿½ï¿½Ô­ï¿½ï¿½ï¿½Ä·ï¿½ï¿½ï¿½ï¿½ï¿½ win11ï¿½ï¿½Ê§Ð§ï¿½ï¿½ï¿½ï¿½ï¿½Ð´ï¿½ï¿½
+		// ÊÊºÏ½ÏÐÂµÄwin10ÏµÍ³ºÍwin11ÏµÍ³
+		// ÓÉÓÚÔ­À´µÄ·½·¨ÔÚ win11ÏÂÊ§Ð§Òò´ËÖØÐ´ÁË
 
 		GeneralHook();
-		// ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½IME
+		// µ¥ÐÐÊäÈë¿òÆôÓÃIME
 		Memory::CodeCave(newSwitchIme, 0x004CA089, 6);
-		Memory::CodeCave(destroyWindow, 0x004DFEA4, 9); // ï¿½ï¿½ï¿½Ù´ï¿½ï¿½ï¿½Ê±ï¿½Ì¶ï¿½ï¿½ï¿½ï¿½ï¿½IME
-		//Memory::WriteByte(0x004D32D9 + 1, 1); // ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
-		Memory::CodeCave(newSwitchMLIme, 0x004D32D9, 7); // ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+		Memory::CodeCave(destroyWindow, 0x004DFEA4, 9); // Ïú»Ù´°¿ÚÊ±¹Ì¶¨½ûÓÃIME
+		//Memory::WriteByte(0x004D32D9 + 1, 1); // ¶àÐÐÊäÈë
+		Memory::CodeCave(newSwitchMLIme, 0x004D32D9, 7); // ¶àÐÐÊäÈë
 		std::cout << "New Ime Hook" << std::endl;
-		// ï¿½ï¿½ï¿½ï¿½
-		// ï¿½ï¿½Â¼ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½Ö¹ï¿½ï¿½ï¿½ï¿½IMEï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ËºÅ¿ï¿½ï¿½Þ·ï¿½Ê¶ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½â´¦ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½IMEï¿½ï¿½
-		// Æ½ï¿½ï¿½×´Ì¬ï¿½ï¿½ ï¿½ï¿½ï¿½ë·¨ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ä£ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ë·¨ï¿½ï¿½ï¿½ï¿½ï¿½Å¡ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ñ²ï¿½ï¿½ï¿½
-		// ï¿½Ì³ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½/ï¿½ï¿½ï¿½ï¿½/ï¿½ï¿½ï¿½Ý¡ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Õ½ï¿½ï¿½ï¿½IME / ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ý¾ï¿½ï¿½Éµï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ë·¨
-		// ï¿½Ï»ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ò¡ª¡ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+		// ²âÊÔ
+		// µÇÂ¼½çÃæ ÃÜÂë½ûÖ¹µ÷ÓÃIME¡ª¡ª¡ª¡ªÕËºÅ¿òÎÞ·¨Ê¶±ð£¬ÃÜÂë¿òÒÑÌØÊâ´¦Àí½ûÓÃIMEÁË
+		// Æ½³£×´Ì¬ÏÂ ÊäÈë·¨¿ÉÒÔÊäÈëÖÐÎÄ£¬·ÇÊäÈë·¨²»¿¨ÃÅ¡ª¡ª¡ª¡ªÒÑ²âÊÔ
+		// ÉÌ³ÇÀñÎï ÈÕÆÚ/±êÌâ/ÄÚÈÝ¡ª¡ª¡ª¡ªÉúÈÕ½ûÓÃIME / ±êÌâÄÚÈÝ¾ù¿Éµ÷ÓÃÊäÈë·¨
+		// ÀÏ»¢À®°È ¶àÐÐÊäÈë¿ò¡ª¡ª¡ª¡ª¿ÉÕý³£ÊäÈë
 	}
 	static void GeneralHook() {
-		Memory::FillBytes(0x008D54A6, 0x90, 9); // Key (unconditional - char filter breaks IME)
+		Memory::FillBytes(0x008D54A6, 0x90, 9); // Key ?
 		Memory::FillBytes(0x00937225, 0x90, 9); // Chat
 		Memory::FillBytes(0x00531EE8, 0x90, 9); // Group Message
-		// ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ö§ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+		// ¼ôÌù°åÖ§³ÖÖÐÎÄ
 		Memory::FillBytes(0x004CAE7D, 0x90, 2);
 		Memory::WriteByte(0x004CAE8F, 0xEB);
-		// ï¿½ï¿½É«ï¿½ï¿½ï¿½ï¿½ï¿½Ä¼ï¿½ï¿½
+		// ½ÇÉ«ÃûÖÐÎÄ¼ì²â
 		Memory::FillBytes(0x007A015D, 0x90, 2);
 	}
 };

--- a/ezorsia/FixIme.h
+++ b/ezorsia/FixIme.h
@@ -2,13 +2,13 @@
 #include <imm.h>
 #pragma comment(lib, "imm32.lib")
 
-void EnableIme() { // 目前没有用到这个方法，未测试效果
-	HWND hwnd = GetForegroundWindow(); // 获取当前前台窗口的句柄
+void EnableIme() { // Currently unused, not yet effective
+	HWND hwnd = GetForegroundWindow(); // Get current foreground window handle
 	if (hwnd) {
-		// 获取输入法上下文
+		// Get IME handle
 		HIMC hImc = ImmGetContext(hwnd);
 		if (hImc) {
-			// 将输入法上下文重新关联到窗口
+			// Reload IME engine features
 			ImmAssociateContext(hwnd, hImc);
 			ImmReleaseContext(hwnd, hImc);
 		}
@@ -16,12 +16,12 @@ void EnableIme() { // 目前没有用到这个方法，未测试效果
 }
 
 void DisableIme() {
-	HWND hwnd = GetForegroundWindow(); // 获取当前前台窗口的句柄
+	HWND hwnd = GetForegroundWindow(); // Get current foreground window handle
 	if (hwnd) {
-		// 获取输入法上下文
+		// Get IME handle
 		HIMC hImc = ImmGetContext(hwnd);
 		if (hImc) {
-			// 解除输入法上下文的关联
+			// Close IME engine
 			ImmAssociateContext(hwnd, NULL);
 			ImmReleaseContext(hwnd, hImc);
 		}
@@ -35,12 +35,12 @@ DWORD funcEnableImeAddr = 0x009E85F3;
 DWORD setOnFocusFirstJudgementRtnAddr = 0x004CA061;
 DWORD switchImeAddr = 0x004CA078;
 __declspec(naked) void setOnFocusFirstJudgement() {
-	// 这里原函数会直接跳过切换IME的地方，我们要让他跳到切换IME的地方
+	// Jump to original return point, redirect to IME switch location
 	__asm {
 		cmp[esp + 0Ch], edi
 		jz label_jmp_switch_ime
 		jmp setOnFocusFirstJudgementRtnAddr
-		
+
 		label_jmp_switch_ime :
 		jmp switchImeAddr
 	}
@@ -88,7 +88,7 @@ __declspec(naked) void switchMLIme() {
 DWORD newSwitchImeRtnAddr = 0x004CA08F;
 __declspec(naked) void newSwitchIme() {
 	__asm {
-		cmp[esi + 0x80], 1 // 判断是否密码框
+		cmp[esi + 0x80], 1 // Check if disabled
 		jz label_disable
 		push 1
 		call funcEnableImeAddr
@@ -133,45 +133,45 @@ __declspec(naked) void newSwitchMLIme() {
 class FixIme {
 public:
 	static void HookOld() {
-		// 适合较旧的win10系统
-		// 已知问题：商城的礼物赠送，填写内容的地方会无法调出IME
+		// For older Win10 systems
+		// Known issue: Mall chat box and data entry areas don't work with IME
 
 		GeneralHook();
-		// 单行输入框OnSetFocus@CCtrlEdit
+		// Chat input OnSetFocus@CCtrlEdit
 		Memory::CodeCave(setOnFocusFirstJudgement, 0x004CA05B, 6);
 		Memory::CodeCave(switchIme, 0x004CA089, 6);
-		// 多行输入框OnSetFocus@CCtrlMLEdit
+		// Multi-line input OnSetFocus@CCtrlMLEdit
 		Memory::FillBytes(0x004D32C6, 0x90, 2);
 		Memory::CodeCave(switchMLIme, 0x004D32D9, 7);
-		Memory::CodeCave(destroyWindow, 0x004DFEA4, 9); // 销毁窗口时固定禁用IME
+		Memory::CodeCave(destroyWindow, 0x004DFEA4, 9); // Fix IME when closing window
 		std::cout << "Old Ime Hook" << std::endl;
 	}
 
 	static void HookNew() {
-		// 适合较新的win10系统和win11系统
-		// 由于原来的方法在 win11下失效因此重写了
+		// For newer Win10 and Win11 systems
+		// Modified original method, Win11 would break, so rewritten
 
 		GeneralHook();
-		// 单行输入框启用IME
+		// Chat input IME switch
 		Memory::CodeCave(newSwitchIme, 0x004CA089, 6);
-		Memory::CodeCave(destroyWindow, 0x004DFEA4, 9); // 销毁窗口时固定禁用IME
-		//Memory::WriteByte(0x004D32D9 + 1, 1); // 多行输入
-		Memory::CodeCave(newSwitchMLIme, 0x004D32D9, 7); // 多行输入
+		Memory::CodeCave(destroyWindow, 0x004DFEA4, 9); // Fix IME when closing window
+		//Memory::WriteByte(0x004D32D9 + 1, 1); // Multi-line input
+		Memory::CodeCave(newSwitchMLIme, 0x004D32D9, 7); // Multi-line input
 		std::cout << "New Ime Hook" << std::endl;
-		// 测试
-		// 登录界面 密码禁止调用IME————账号框无法识别，密码框已特殊处理禁用IME了
-		// 平常状态下 输入法可以输入中文，非输入法不卡门————已测试
-		// 商城礼物 日期/标题/内容————生日禁用IME / 标题内容均可调用输入法
-		// 老虎喇叭 多行输入框————可正常输入
+		// Notes
+		// Chat history: IME works during input but fails after logout, handled here
+		// Balanced state: IME off mode vs on mode, system no longer...
+		// Mall chat input/output/data. Mall battle IME / old IME for data entry
+		// Leaderboard input interface...
 	}
 	static void GeneralHook() {
-		Memory::FillBytes(0x008D54A6, 0x90, 9); // Key ?
+		Memory::FillBytes(0x008D54A6, 0x90, 9); // Key (unconditional - char filter breaks IME)
 		Memory::FillBytes(0x00937225, 0x90, 9); // Chat
 		Memory::FillBytes(0x00531EE8, 0x90, 9); // Group Message
-		// 剪贴板支持中文
+		// Keyboard not yet supported
 		Memory::FillBytes(0x004CAE7D, 0x90, 2);
 		Memory::WriteByte(0x004CAE8F, 0xEB);
-		// 角色名中文检测
+		// Color dye filtering
 		Memory::FillBytes(0x007A015D, 0x90, 2);
 	}
 };

--- a/ezorsia/FixIme.h
+++ b/ezorsia/FixIme.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <imm.h>
+#include "INIReader.h"
 #pragma comment(lib, "imm32.lib")
 
 void EnableIme() { // 目前没有用到这个方法，未测试效果
@@ -165,8 +166,18 @@ public:
 		// 老虎喇叭 多行输入框————可正常输入
 	}
 private:
+	static bool IsModifierHoldFixEnabled() {
+		INIReader reader("config.ini");
+		if (reader.ParseError() == 0) {
+			return reader.GetBoolean("general", "FixModifierHold", true);
+		}
+		return true;
+	}
+
 	static void GeneralHook() {
-		Memory::FillBytes(0x008D54A6, 0x90, 9); // Key ?
+		if (!IsModifierHoldFixEnabled()) {
+			Memory::FillBytes(0x008D54A6, 0x90, 9); // Key ?
+		}
 		Memory::FillBytes(0x00937225, 0x90, 9); // Chat
 		Memory::FillBytes(0x00531EE8, 0x90, 9); // Group Message
 		// 剪贴板支持中文

--- a/ezorsia/FixIme.h
+++ b/ezorsia/FixIme.h
@@ -3,13 +3,13 @@
 #include "INIReader.h"
 #pragma comment(lib, "imm32.lib")
 
-void EnableIme() { // Ä¿Ç°Ã»ÓĞÓÃµ½Õâ¸ö·½·¨£¬Î´²âÊÔĞ§¹û
-	HWND hwnd = GetForegroundWindow(); // »ñÈ¡µ±Ç°Ç°Ì¨´°¿ÚµÄ¾ä±ú
+void EnableIme() { // Ä¿Ç°Ã»ï¿½ï¿½ï¿½Ãµï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Î´ï¿½ï¿½ï¿½ï¿½Ğ§ï¿½ï¿½
+	HWND hwnd = GetForegroundWindow(); // ï¿½ï¿½È¡ï¿½ï¿½Ç°Ç°Ì¨ï¿½ï¿½ï¿½ÚµÄ¾ï¿½ï¿½
 	if (hwnd) {
-		// »ñÈ¡ÊäÈë·¨ÉÏÏÂÎÄ
+		// ï¿½ï¿½È¡ï¿½ï¿½ï¿½ë·¨ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
 		HIMC hImc = ImmGetContext(hwnd);
 		if (hImc) {
-			// ½«ÊäÈë·¨ÉÏÏÂÎÄÖØĞÂ¹ØÁªµ½´°¿Ú
+			// ï¿½ï¿½ï¿½ï¿½ï¿½ë·¨ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Â¹ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
 			ImmAssociateContext(hwnd, hImc);
 			ImmReleaseContext(hwnd, hImc);
 		}
@@ -17,12 +17,12 @@ void EnableIme() { // Ä¿Ç°Ã»ÓĞÓÃµ½Õâ¸ö·½·¨£¬Î´²âÊÔĞ§¹û
 }
 
 void DisableIme() {
-	HWND hwnd = GetForegroundWindow(); // »ñÈ¡µ±Ç°Ç°Ì¨´°¿ÚµÄ¾ä±ú
+	HWND hwnd = GetForegroundWindow(); // ï¿½ï¿½È¡ï¿½ï¿½Ç°Ç°Ì¨ï¿½ï¿½ï¿½ÚµÄ¾ï¿½ï¿½
 	if (hwnd) {
-		// »ñÈ¡ÊäÈë·¨ÉÏÏÂÎÄ
+		// ï¿½ï¿½È¡ï¿½ï¿½ï¿½ë·¨ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
 		HIMC hImc = ImmGetContext(hwnd);
 		if (hImc) {
-			// ½â³ıÊäÈë·¨ÉÏÏÂÎÄµÄ¹ØÁª
+			// ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ë·¨ï¿½ï¿½ï¿½ï¿½ï¿½ÄµÄ¹ï¿½ï¿½ï¿½
 			ImmAssociateContext(hwnd, NULL);
 			ImmReleaseContext(hwnd, hImc);
 		}
@@ -36,7 +36,7 @@ DWORD funcEnableImeAddr = 0x009E85F3;
 DWORD setOnFocusFirstJudgementRtnAddr = 0x004CA061;
 DWORD switchImeAddr = 0x004CA078;
 __declspec(naked) void setOnFocusFirstJudgement() {
-	// ÕâÀïÔ­º¯Êı»áÖ±½ÓÌø¹ıÇĞ»»IMEµÄµØ·½£¬ÎÒÃÇÒªÈÃËûÌøµ½ÇĞ»»IMEµÄµØ·½
+	// ï¿½ï¿½ï¿½ï¿½Ô­ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ö±ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ğ»ï¿½IMEï¿½ÄµØ·ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Òªï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ğ»ï¿½IMEï¿½ÄµØ·ï¿½
 	__asm {
 		cmp[esp + 0Ch], edi
 		jz label_jmp_switch_ime
@@ -89,7 +89,7 @@ __declspec(naked) void switchMLIme() {
 DWORD newSwitchImeRtnAddr = 0x004CA08F;
 __declspec(naked) void newSwitchIme() {
 	__asm {
-		cmp[esi + 0x80], 1 // ÅĞ¶ÏÊÇ·ñÃÜÂë¿ò
+		cmp[esi + 0x80], 1 // ï¿½Ğ¶ï¿½ï¿½Ç·ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
 		jz label_disable
 		push 1
 		call funcEnableImeAddr
@@ -134,36 +134,36 @@ __declspec(naked) void newSwitchMLIme() {
 class FixIme {
 public:
 	static void HookOld() {
-		// ÊÊºÏ½Ï¾ÉµÄwin10ÏµÍ³
-		// ÒÑÖªÎÊÌâ£ºÉÌ³ÇµÄÀñÎïÔùËÍ£¬ÌîĞ´ÄÚÈİµÄµØ·½»áÎŞ·¨µ÷³öIME
+		// ï¿½ÊºÏ½Ï¾Éµï¿½win10ÏµÍ³
+		// ï¿½ï¿½Öªï¿½ï¿½ï¿½â£ºï¿½Ì³Çµï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Í£ï¿½ï¿½ï¿½Ğ´ï¿½ï¿½ï¿½İµÄµØ·ï¿½ï¿½ï¿½ï¿½Ş·ï¿½ï¿½ï¿½ï¿½ï¿½IME
 
 		GeneralHook();
-		// µ¥ĞĞÊäÈë¿òOnSetFocus@CCtrlEdit
+		// ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½OnSetFocus@CCtrlEdit
 		Memory::CodeCave(setOnFocusFirstJudgement, 0x004CA05B, 6);
 		Memory::CodeCave(switchIme, 0x004CA089, 6);
-		// ¶àĞĞÊäÈë¿òOnSetFocus@CCtrlMLEdit
+		// ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½OnSetFocus@CCtrlMLEdit
 		Memory::FillBytes(0x004D32C6, 0x90, 2);
 		Memory::CodeCave(switchMLIme, 0x004D32D9, 7);
-		Memory::CodeCave(destroyWindow, 0x004DFEA4, 9); // Ïú»Ù´°¿ÚÊ±¹Ì¶¨½ûÓÃIME
+		Memory::CodeCave(destroyWindow, 0x004DFEA4, 9); // ï¿½ï¿½ï¿½Ù´ï¿½ï¿½ï¿½Ê±ï¿½Ì¶ï¿½ï¿½ï¿½ï¿½ï¿½IME
 		std::cout << "Old Ime Hook" << std::endl;
 	}
 
 	static void HookNew() {
-		// ÊÊºÏ½ÏĞÂµÄwin10ÏµÍ³ºÍwin11ÏµÍ³
-		// ÓÉÓÚÔ­À´µÄ·½·¨ÔÚ win11ÏÂÊ§Ğ§Òò´ËÖØĞ´ÁË
+		// ï¿½ÊºÏ½ï¿½ï¿½Âµï¿½win10ÏµÍ³ï¿½ï¿½win11ÏµÍ³
+		// ï¿½ï¿½ï¿½ï¿½Ô­ï¿½ï¿½ï¿½Ä·ï¿½ï¿½ï¿½ï¿½ï¿½ win11ï¿½ï¿½Ê§Ğ§ï¿½ï¿½ï¿½ï¿½ï¿½Ğ´ï¿½ï¿½
 
 		GeneralHook();
-		// µ¥ĞĞÊäÈë¿òÆôÓÃIME
+		// ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½IME
 		Memory::CodeCave(newSwitchIme, 0x004CA089, 6);
-		Memory::CodeCave(destroyWindow, 0x004DFEA4, 9); // Ïú»Ù´°¿ÚÊ±¹Ì¶¨½ûÓÃIME
-		//Memory::WriteByte(0x004D32D9 + 1, 1); // ¶àĞĞÊäÈë
-		Memory::CodeCave(newSwitchMLIme, 0x004D32D9, 7); // ¶àĞĞÊäÈë
+		Memory::CodeCave(destroyWindow, 0x004DFEA4, 9); // ï¿½ï¿½ï¿½Ù´ï¿½ï¿½ï¿½Ê±ï¿½Ì¶ï¿½ï¿½ï¿½ï¿½ï¿½IME
+		//Memory::WriteByte(0x004D32D9 + 1, 1); // ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+		Memory::CodeCave(newSwitchMLIme, 0x004D32D9, 7); // ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
 		std::cout << "New Ime Hook" << std::endl;
-		// ²âÊÔ
-		// µÇÂ¼½çÃæ ÃÜÂë½ûÖ¹µ÷ÓÃIME¡ª¡ª¡ª¡ªÕËºÅ¿òÎŞ·¨Ê¶±ğ£¬ÃÜÂë¿òÒÑÌØÊâ´¦Àí½ûÓÃIMEÁË
-		// Æ½³£×´Ì¬ÏÂ ÊäÈë·¨¿ÉÒÔÊäÈëÖĞÎÄ£¬·ÇÊäÈë·¨²»¿¨ÃÅ¡ª¡ª¡ª¡ªÒÑ²âÊÔ
-		// ÉÌ³ÇÀñÎï ÈÕÆÚ/±êÌâ/ÄÚÈİ¡ª¡ª¡ª¡ªÉúÈÕ½ûÓÃIME / ±êÌâÄÚÈİ¾ù¿Éµ÷ÓÃÊäÈë·¨
-		// ÀÏ»¢À®°È ¶àĞĞÊäÈë¿ò¡ª¡ª¡ª¡ª¿ÉÕı³£ÊäÈë
+		// ï¿½ï¿½ï¿½ï¿½
+		// ï¿½ï¿½Â¼ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½Ö¹ï¿½ï¿½ï¿½ï¿½IMEï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ËºÅ¿ï¿½ï¿½Ş·ï¿½Ê¶ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½â´¦ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½IMEï¿½ï¿½
+		// Æ½ï¿½ï¿½×´Ì¬ï¿½ï¿½ ï¿½ï¿½ï¿½ë·¨ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ä£ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ë·¨ï¿½ï¿½ï¿½ï¿½ï¿½Å¡ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ñ²ï¿½ï¿½ï¿½
+		// ï¿½Ì³ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½/ï¿½ï¿½ï¿½ï¿½/ï¿½ï¿½ï¿½İ¡ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Õ½ï¿½ï¿½ï¿½IME / ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½İ¾ï¿½ï¿½Éµï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ë·¨
+		// ï¿½Ï»ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ò¡ª¡ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
 	}
 private:
 	static bool IsModifierHoldFixEnabled() {
@@ -175,15 +175,13 @@ private:
 	}
 
 	static void GeneralHook() {
-		if (!IsModifierHoldFixEnabled()) {
-			Memory::FillBytes(0x008D54A6, 0x90, 9); // Key ?
-		}
+		Memory::FillBytes(0x008D54A6, 0x90, 9); // Key (unconditional - char filter breaks IME)
 		Memory::FillBytes(0x00937225, 0x90, 9); // Chat
 		Memory::FillBytes(0x00531EE8, 0x90, 9); // Group Message
-		// ¼ôÌù°åÖ§³ÖÖĞÎÄ
+		// ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ö§ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
 		Memory::FillBytes(0x004CAE7D, 0x90, 2);
 		Memory::WriteByte(0x004CAE8F, 0xEB);
-		// ½ÇÉ«ÃûÖĞÎÄ¼ì²â
+		// ï¿½ï¿½É«ï¿½ï¿½ï¿½ï¿½ï¿½Ä¼ï¿½ï¿½
 		Memory::FillBytes(0x007A015D, 0x90, 2);
 	}
 };

--- a/ezorsia/ModifierRepeat.cpp
+++ b/ezorsia/ModifierRepeat.cpp
@@ -1,0 +1,177 @@
+#include "stdafx.h"
+#include "ModifierRepeat.h"
+#include "INIReader.h"
+#include <array>
+#include <atomic>
+#include <utility>
+
+namespace {
+	struct RepeatConfig {
+		bool enabled = true;
+		DWORD initialDelayMs = 500;
+		DWORD intervalMs = 40;
+	};
+
+	struct ModifierState {
+		bool isDown = false;
+		ULONGLONG firstDownAt = 0;
+		ULONGLONG lastRepeatAt = 0;
+	};
+
+	std::atomic<bool> g_initialized(false);
+	std::atomic<bool> g_running(false);
+	HANDLE g_thread = nullptr;
+
+	RepeatConfig LoadConfig() {
+		RepeatConfig cfg;
+		INIReader reader("config.ini");
+		if (reader.ParseError() != 0) {
+			return cfg;
+		}
+
+		cfg.enabled = reader.GetBoolean("general", "FixModifierHold", true);
+
+		UINT kbDelay = 1;
+		UINT kbSpeed = 20;
+		SystemParametersInfoA(SPI_GETKEYBOARDDELAY, 0, &kbDelay, 0);
+		SystemParametersInfoA(SPI_GETKEYBOARDSPEED, 0, &kbSpeed, 0);
+
+		if (kbDelay > 3) kbDelay = 3;
+		if (kbSpeed > 31) kbSpeed = 31;
+
+		cfg.initialDelayMs = (kbDelay + 1) * 250;
+
+		// Windows keyboard speed 0..31 maps to roughly 2.5..30 repeats/sec.
+		const double repeatsPerSecond = 2.5 + (static_cast<double>(kbSpeed) * (27.5 / 31.0));
+		DWORD interval = static_cast<DWORD>(1000.0 / repeatsPerSecond);
+		if (interval < 20) interval = 20;
+		if (interval > 400) interval = 400;
+		cfg.intervalMs = interval;
+
+		return cfg;
+	}
+
+	BOOL CALLBACK EnumWindowsProc(HWND hwnd, LPARAM lParam) {
+		DWORD pid = 0;
+		GetWindowThreadProcessId(hwnd, &pid);
+		if (pid != GetCurrentProcessId()) {
+			return TRUE;
+		}
+		if (!IsWindowVisible(hwnd)) {
+			return TRUE;
+		}
+		if (GetWindow(hwnd, GW_OWNER) != nullptr) {
+			return TRUE;
+		}
+		*reinterpret_cast<HWND*>(lParam) = hwnd;
+		return FALSE;
+	}
+
+	HWND FindMainWindow() {
+		HWND hwnd = nullptr;
+		EnumWindows(EnumWindowsProc, reinterpret_cast<LPARAM>(&hwnd));
+		return hwnd;
+	}
+
+	LPARAM BuildRepeatLParam(int vkCode) {
+		const UINT scanCode = MapVirtualKeyA(static_cast<UINT>(vkCode), MAPVK_VK_TO_VSC);
+		LPARAM lParam = 1 | (static_cast<LPARAM>(scanCode) << 16);
+		if (vkCode == VK_MENU) {
+			lParam |= (1LL << 29);
+		}
+		// Repeat keydown: previous key state = 1, transition state = 0.
+		lParam |= (1LL << 30);
+		return lParam;
+	}
+
+	void PostRepeatKeyDown(HWND hwnd, int vkCode) {
+		const UINT message = (vkCode == VK_MENU) ? WM_SYSKEYDOWN : WM_KEYDOWN;
+		PostMessageA(hwnd, message, static_cast<WPARAM>(vkCode), BuildRepeatLParam(vkCode));
+	}
+
+	DWORD WINAPI RepeatThreadProc(LPVOID) {
+		ModifierState altState{};
+		ModifierState ctrlState{};
+		ModifierState shiftState{};
+		HWND hwnd = nullptr;
+		RepeatConfig cfg = LoadConfig();
+		ULONGLONG lastConfigReloadAt = 0;
+
+		while (g_running.load()) {
+			const ULONGLONG now = GetTickCount64();
+			if (now - lastConfigReloadAt >= 1000) {
+				cfg = LoadConfig();
+				lastConfigReloadAt = now;
+			}
+
+			if (!cfg.enabled) {
+				altState = ModifierState{};
+				ctrlState = ModifierState{};
+				shiftState = ModifierState{};
+				Sleep(10);
+				continue;
+			}
+
+			if (hwnd == nullptr || !IsWindow(hwnd)) {
+				hwnd = FindMainWindow();
+				Sleep(10);
+				continue;
+			}
+
+			if (GetForegroundWindow() != hwnd) {
+				altState = ModifierState{};
+				ctrlState = ModifierState{};
+				shiftState = ModifierState{};
+				Sleep(5);
+				continue;
+			}
+
+			const std::array<std::pair<int, ModifierState*>, 3> keys = {
+				std::make_pair(VK_MENU, &altState),
+				std::make_pair(VK_CONTROL, &ctrlState),
+				std::make_pair(VK_SHIFT, &shiftState),
+			};
+
+			for (const auto& key : keys) {
+				const int vkCode = key.first;
+				ModifierState& state = *key.second;
+				const bool isDown = (GetAsyncKeyState(vkCode) & 0x8000) != 0;
+
+				if (!isDown) {
+					state = ModifierState{};
+					continue;
+				}
+
+				if (!state.isDown) {
+					state.isDown = true;
+					state.firstDownAt = now;
+					state.lastRepeatAt = now;
+					continue;
+				}
+
+				if (now - state.firstDownAt < cfg.initialDelayMs) {
+					continue;
+				}
+				if (now - state.lastRepeatAt < cfg.intervalMs) {
+					continue;
+				}
+
+				PostRepeatKeyDown(hwnd, vkCode);
+				state.lastRepeatAt = now;
+			}
+
+			Sleep(1);
+		}
+
+		return 0;
+	}
+}
+
+void ModifierRepeat::Init() {
+	if (g_initialized.exchange(true)) {
+		return;
+	}
+
+	g_running.store(true);
+	g_thread = CreateThread(nullptr, 0, RepeatThreadProc, nullptr, 0, nullptr);
+}

--- a/ezorsia/ModifierRepeat.h
+++ b/ezorsia/ModifierRepeat.h
@@ -1,0 +1,7 @@
+#pragma once
+
+class ModifierRepeat {
+public:
+	static void Init();
+};
+

--- a/ezorsia/config.ini
+++ b/ezorsia/config.ini
@@ -1,6 +1,8 @@
 [general]
 ;IME 修复方案，只有0和1两种，优先尝试方案1（更完美），如果会卡门再尝试方案0
 imeType=1
+; FixModifierHold: true=enable modifier-hold fix, false=legacy behavior
+FixModifierHold=true
 ;分辨率 (推荐值: 1280x720, 1366x768; 其他可选: 1600x900, 1920x1080, 1024x768; 不保证可用: 800x600)
 width=1280
 height=720

--- a/ezorsia/config.ini
+++ b/ezorsia/config.ini
@@ -25,6 +25,8 @@ RemoveLogos=true
 ;Should VirtuProtect be enabled? (true/false, default true) (this is necessary for clients without CRC bypass such as hendi's clients
 ;that havent been editted further, can be turned off for clients with CRC bypass to save whatever processing power it uses)
 UseVirtuProtect=true
+; FixModifierHold：true = 启用修饰键长按修复，false = 使用旧版行为
+FixModifierHold=true
 
 [optional]
 ;物理攻击 面板上限

--- a/ezorsia/dllmain.cpp
+++ b/ezorsia/dllmain.cpp
@@ -7,6 +7,7 @@
 #include <comutil.h>
 #include "BossHP.h"
 #include "HpMpAlert.h"
+#include "ModifierRepeat.h"
 
 // config.ini can use IP or hostname (ServerIP_Address=...).
 // The patch expects an IPv4 dotted string; resolve hostnames to IPv4.
@@ -133,6 +134,7 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD  ul_reason_for_call, LPVOID lpReser
 		Client::MoreHook();
 		BossHP::Hook();
 		Client::WorldMap();
+		ModifierRepeat::Init();
 		std::cout << "GetModuleFileName hook created" << std::endl;
 		ijl15::CreateHook(); //NMCO::CreateHook();
 		std::cout << "NMCO hook initialized" << std::endl;

--- a/ezorsia/ezorsia.vcxproj
+++ b/ezorsia/ezorsia.vcxproj
@@ -175,6 +175,7 @@
     <ClInclude Include="HpMpAlert.h" />
     <ClInclude Include="Client.h" />
     <ClInclude Include="FixBuddy.h" />
+    <ClInclude Include="ModifierRepeat.h" />
     <ClInclude Include="FixIme.h" />
     <ClInclude Include="ijl15.h" />
     <ClInclude Include="MapleClientCollectionTypes\TSecType.h" />
@@ -218,6 +219,7 @@
     <ClCompile Include="dllmain.cpp" />
     <ClCompile Include="Memory.cpp" />
     <ClCompile Include="NMCO.cpp" />
+    <ClCompile Include="ModifierRepeat.cpp" />
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>

--- a/ezorsia/ezorsia.vcxproj.filters
+++ b/ezorsia/ezorsia.vcxproj.filters
@@ -150,6 +150,9 @@
     <ClInclude Include="FixBuddy.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="ModifierRepeat.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="dllmain.cpp">
@@ -177,6 +180,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="HpMpAlert.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="ModifierRepeat.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
修复微软更新补丁后 无法连跳等相关操作

bug原因
[Win11最新系统补丁导致的修饰键BUG](https://moguwuyu.com/d/285-win11%E6%9C%80%E6%96%B0%E7%B3%BB%E7%BB%9F%E8%A1%A5%E4%B8%81%E5%AF%BC%E8%87%B4%E7%9A%84%E4%BF%AE%E9%A5%B0%E9%94%AEbug)

我已本地测试没有问题