### PR TITLE
feat: add auto login support with config.ini control

### DIFF
--- a/ezorsia/AutoLogin.cpp
+++ b/ezorsia/AutoLogin.cpp
@@ -1,0 +1,136 @@
+#include "stdafx.h"
+#include "AutoLogin.h"
+#include "Memory.h"
+
+namespace {
+constexpr DWORD kCLoginUpdateAddr = 0x005F4C16;
+constexpr DWORD kSendCheckPasswordPacketAddr = 0x005F6952;
+constexpr DWORD kSendSelectWorldAddr = 0x005F6D6A;
+
+constexpr DWORD kOffsetStep = 0x168;
+constexpr DWORD kOffsetStepTime = 0x16C;
+constexpr DWORD kOffsetRequestSent = 0x170;
+constexpr DWORD kOffsetWorldItem = 0x18C;
+
+enum class AutoLoginPhase {
+    INIT,
+    WAIT_LOGIN_READY,
+    LOGIN_PACKET_SENT,
+    WAIT_WORLD_READY,
+    WORLD_PACKET_SENT,
+    CHAR_SELECT_REACHED,
+    FAILED
+};
+
+static bool g_bEnabled = false;
+static std::string g_Username;
+static std::string g_Password;
+static int g_nWorld = 0;
+static int g_nChannel = 0;
+
+static AutoLoginPhase g_Phase = AutoLoginPhase::INIT;
+static DWORD g_dwPhaseStartTick = 0;
+
+using CLogin__Update_t = void(__fastcall*)(void* pThis, void* edx);
+static CLogin__Update_t s_CLogin__Update = reinterpret_cast<CLogin__Update_t>(kCLoginUpdateAddr);
+
+using SendCheckPasswordPacket_t = int(__fastcall*)(void* pThis, void* edx, const char* sID, const char* sPasswd);
+static SendCheckPasswordPacket_t s_SendCheckPasswordPacket = reinterpret_cast<SendCheckPasswordPacket_t>(kSendCheckPasswordPacketAddr);
+
+using SendSelectWorld_t = int(__fastcall*)(void* pThis, void* edx, int nWorldId, int nChannelId);
+static SendSelectWorld_t s_SendSelectWorld = reinterpret_cast<SendSelectWorld_t>(kSendSelectWorldAddr);
+
+static void __fastcall CLogin__Update_Hook(void* pThis, void* edx) {
+    if (s_CLogin__Update) {
+        s_CLogin__Update(pThis, edx);
+    }
+
+    if (!g_bEnabled || pThis == nullptr) {
+        return;
+    }
+
+    if (g_Username.empty()) {
+        return;
+    }
+
+    __try {
+        const DWORD now = GetTickCount();
+        const int nStep = *reinterpret_cast<const int*>((uintptr_t)pThis + kOffsetStep);
+        const DWORD tStepTime = *reinterpret_cast<const DWORD*>((uintptr_t)pThis + kOffsetStepTime);
+        const int bRequestSent = *reinterpret_cast<const int*>((uintptr_t)pThis + kOffsetRequestSent);
+
+        switch (g_Phase) {
+        case AutoLoginPhase::INIT:
+            if (nStep == 0) {
+                g_Phase = AutoLoginPhase::WAIT_LOGIN_READY;
+                g_dwPhaseStartTick = now;
+            }
+            break;
+
+        case AutoLoginPhase::WAIT_LOGIN_READY:
+            if (nStep == 0 && tStepTime == 0 && bRequestSent == 0) {
+                if (now - g_dwPhaseStartTick >= 500) {
+                    s_SendCheckPasswordPacket(pThis, nullptr, g_Username.c_str(), g_Password.c_str());
+                    g_Phase = AutoLoginPhase::LOGIN_PACKET_SENT;
+                    g_dwPhaseStartTick = now;
+                }
+            }
+            break;
+
+        case AutoLoginPhase::LOGIN_PACKET_SENT:
+            if (nStep == 1) {
+                g_Phase = AutoLoginPhase::WAIT_WORLD_READY;
+                g_dwPhaseStartTick = now;
+            } else if (now - g_dwPhaseStartTick > 15000) {
+                g_Phase = AutoLoginPhase::FAILED;
+            }
+            break;
+
+        case AutoLoginPhase::WAIT_WORLD_READY:
+            if (nStep == 1 && tStepTime == 0 && bRequestSent == 0) {
+                const DWORD worldItems = *reinterpret_cast<const DWORD*>((uintptr_t)pThis + kOffsetWorldItem);
+                if (worldItems != 0 && (now - g_dwPhaseStartTick >= 300)) {
+                    s_SendSelectWorld(pThis, nullptr, g_nWorld, g_nChannel);
+                    g_Phase = AutoLoginPhase::WORLD_PACKET_SENT;
+                    g_dwPhaseStartTick = now;
+                }
+            }
+            break;
+
+        case AutoLoginPhase::WORLD_PACKET_SENT:
+            if (nStep == 2) {
+                // Arrived at character selection screen; stop and stay here.
+                g_Phase = AutoLoginPhase::CHAR_SELECT_REACHED;
+            } else if (now - g_dwPhaseStartTick > 15000) {
+                g_Phase = AutoLoginPhase::FAILED;
+            }
+            break;
+
+        case AutoLoginPhase::CHAR_SELECT_REACHED:
+        case AutoLoginPhase::FAILED:
+        default:
+            break;
+        }
+    } __except (EXCEPTION_EXECUTE_HANDLER) {
+        // Suppress any memory read/write exception to safeguard game client stability
+    }
+}
+} // namespace
+
+namespace AutoLogin {
+
+void Init(bool bEnable, const std::string& username, const std::string& password, int nWorld, int nChannel) {
+    g_bEnabled = bEnable;
+    g_Username = username;
+    g_Password = password;
+    g_nWorld = nWorld;
+    g_nChannel = nChannel;
+    g_Phase = AutoLoginPhase::INIT;
+    g_dwPhaseStartTick = GetTickCount();
+}
+
+void Hook(bool bEnable) {
+    Memory::SetHook(bEnable, reinterpret_cast<void**>(&s_CLogin__Update), CLogin__Update_Hook);
+}
+
+} // namespace AutoLogin

--- a/ezorsia/AutoLogin.h
+++ b/ezorsia/AutoLogin.h
@@ -1,0 +1,7 @@
+#pragma once
+#include <string>
+
+namespace AutoLogin {
+    void Init(bool bEnable, const std::string& username, const std::string& password, int nWorld = 0, int nChannel = 0);
+    void Hook(bool bEnable);
+}

--- a/ezorsia/config.ini
+++ b/ezorsia/config.ini
@@ -60,3 +60,15 @@ talkTime=2000
 debug=false
 ;免密模式，解除客户端密码限制（须先开启debug）
 noPassword=false
+
+[auto_login]
+;是否开启辅助自动登录 (true/false)
+enable=false
+;自动登录账号
+username=
+;自动登录密码
+password=
+;选择的大区 (默认0: 蓝蜗牛)
+world=0
+;选择的频道 (默认0: 频道1)
+channel=0

--- a/ezorsia/dllmain.cpp
+++ b/ezorsia/dllmain.cpp
@@ -1,4 +1,4 @@
-﻿// dllmain.cpp : Defines the entry point for the DLL application.
+// dllmain.cpp : Defines the entry point for the DLL application.
 #include "stdafx.h"
 #include "NMCO.h"
 #include "ijl15.h"
@@ -8,6 +8,7 @@
 #include "BossHP.h"
 #include "HpMpAlert.h"
 #include "SelectCharMacFix.h"
+#include "AutoLogin.h"
 #pragma comment(lib, "ws2_32.lib")
 
 // config.ini can use IP or hostname (ServerIP_Address=...).
@@ -96,6 +97,28 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD  ul_reason_for_call, LPVOID lpReser
 			Client::climbSpeed = reader.GetFloat("optional", "climbSpeed", 1.0);
 			Client::talkRepeat = reader.GetBoolean("optional", "talkRepeat", false);
 			Client::talkTime = reader.GetInteger("optional", "talkTime", 2000);
+
+			bool autoLogin = reader.GetBoolean("general", "AutoLogin", false);
+			if (!autoLogin) {
+				autoLogin = reader.GetBoolean("auto_login", "enable", false);
+			}
+			std::string autoLoginUsername = reader.Get("general", "AutoLogin_Username", "");
+			if (autoLoginUsername.empty()) {
+				autoLoginUsername = reader.Get("auto_login", "username", "");
+			}
+			std::string autoLoginPassword = reader.Get("general", "AutoLogin_Password", "");
+			if (autoLoginPassword.empty()) {
+				autoLoginPassword = reader.Get("auto_login", "password", "");
+			}
+			int autoLoginWorld = reader.GetInteger("general", "AutoLogin_World", 0);
+			if (autoLoginWorld == 0) {
+				autoLoginWorld = reader.GetInteger("auto_login", "world", 0);
+			}
+			int autoLoginChannel = reader.GetInteger("general", "AutoLogin_Channel", 0);
+			if (autoLoginChannel == 0) {
+				autoLoginChannel = reader.GetInteger("auto_login", "channel", 0);
+			}
+			AutoLogin::Init(autoLogin, autoLoginUsername, autoLoginPassword, autoLoginWorld, autoLoginChannel);
 		}
 
 		Hook_CreateMutexA(true); //multiclient //ty darter, angel, and alias!
@@ -115,6 +138,7 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD  ul_reason_for_call, LPVOID lpReser
 		HookSaveGlobal(true);
 		HookHpMpAlertRecv(true);
 		HookSelectCharMacFix(true);
+		AutoLogin::Hook(true);
 		//Hook_get_unknown(true);
 		//Hook_get_resource_object(true); //helper function hooks  //ty teto for helping me get started
 		//Hook_com_ptr_t_IWzProperty__ctor(true);

--- a/ezorsia/ezorsia.vcxproj
+++ b/ezorsia/ezorsia.vcxproj
@@ -173,6 +173,7 @@
     </ClInclude>
     <ClInclude Include="BossHP.h" />
     <ClInclude Include="HpMpAlert.h" />
+    <ClInclude Include="AutoLogin.h" />
     <ClInclude Include="Client.h" />
     <ClInclude Include="FixBuddy.h" />
     <ClInclude Include="FixIme.h" />
@@ -213,6 +214,7 @@
   <ItemGroup>
     <ClCompile Include="BossHP.cpp" />
     <ClCompile Include="HpMpAlert.cpp" />
+    <ClCompile Include="AutoLogin.cpp" />
     <ClCompile Include="Client.cpp" />
     <ClCompile Include="ijl15.cpp" />
     <ClCompile Include="ZAllocEx.cpp" />

--- a/ezorsia/ezorsia.vcxproj.filters
+++ b/ezorsia/ezorsia.vcxproj.filters
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">
@@ -153,6 +153,9 @@
     <ClInclude Include="SelectCharMacFix.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="AutoLogin.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="dllmain.cpp">
@@ -183,6 +186,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="SelectCharMacFix.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="AutoLogin.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
## Summary
- Add auto-login support to BeiDou-ijl15 client hook dll.
- Read username, password, world, and channel from config.ini.
- Hook CLogin::Update and execute auto-login state machine:
  1. Wait for login frame ready and send check password packet.
  2. Wait for world list and auto-select world (0) & channel (0).
  3. Enter character select screen and stay there.
- Controlled via config.ini key [auto_login] enable or [general] AutoLogin.